### PR TITLE
Always print the output of print() statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Changes in ``pynose`` from legacy ``nose`` include:
 * Fixes all ``flake8`` issues from the original ``nose``.
 * Fixes "ImportError: cannot import name '_TextTestResult' from 'unittest'."
 * Fixes "RuntimeWarning: TestResult has no addDuration method."
-* Replaces the ``imp`` library with the newer ``importlib`` library.
+* Replaces the ``imp`` module with the newer ``importlib`` module.
 * The default logging level now hides "debug" logs for less noise.
+* The ``-s`` option is always active to see the output of ``print()``.
 * Adds ``--co`` as a shortcut to using ``--collect-only``.
 
 --------

--- a/nose/__version__.py
+++ b/nose/__version__.py
@@ -1,2 +1,2 @@
 # pynose nose package
-__version__ = "1.4.3"
+__version__ = "1.4.4"

--- a/nose/plugins/capture.py
+++ b/nose/plugins/capture.py
@@ -22,8 +22,7 @@ class Capture(Plugin):
     appending any output captured to the error or failure output,
     should the test fail or raise an error."""
     enabled = True
-    env_opt = 'NOSE_NOCAPTURE'
-    name = 'capture'
+    name = "capture"
     score = 1600
 
     def __init__(self):
@@ -34,7 +33,7 @@ class Capture(Plugin):
         """Register commandline options"""
         parser.add_option(
             "-s", "--nocapture", action="store_false",
-            default=not env.get(self.env_opt), dest="capture",
+            default=False, dest="capture",
             help="Don't capture stdout (any stdout output "
             "will be printed immediately) [NOSE_NOCAPTURE]"
         )


### PR DESCRIPTION
## Always print the output of ``print()`` statements
* Always print the output of print() statements (``-s`` is always set now)
--> https://github.com/mdmintz/pynose/commit/a50362eb730203fd5377c888b41795e8d03170eb
--> This is the same as ``-s`` always being active.
--> Personally, I've always wanted this, as it's needed for ``pdb`` debugging to work.