### PR TITLE
Fix issue with "inspect" on Python 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ This version of ``nose`` is compatible with Python 3.6+ (including 3.12 & up).
 
 Changes in ``pynose`` from legacy ``nose`` include:
 * Fixes "AttributeError: module 'collections' has no attribute 'Callable'."
-* Fixes all ``flake8`` issues from the original ``nose``.
+* Fixes "AttributeError: module 'inspect' has no attribute 'getargspec'."
 * Fixes "ImportError: cannot import name '_TextTestResult' from 'unittest'."
 * Fixes "RuntimeWarning: TestResult has no addDuration method."
+* Fixes all ``flake8`` issues from the original ``nose``.
 * Replaces the ``imp`` module with the newer ``importlib`` module.
 * The default logging level now hides "debug" logs for less noise.
 * The ``-s`` option is always active to see the output of ``print()``.

--- a/nose/__version__.py
+++ b/nose/__version__.py
@@ -1,2 +1,2 @@
 # pynose nose package
-__version__ = "1.4.4"
+__version__ = "1.4.5"

--- a/nose/plugins/manager.py
+++ b/nose/plugins/manager.py
@@ -49,6 +49,8 @@ from nose.pyversion import sort_list
 __all__ = ['DefaultPluginManager', 'PluginManager', 'EntryPointPluginManager',
            'BuiltinPluginManager', 'RestrictedPluginManager']
 log = logging.getLogger(__name__)
+if not hasattr(inspect, "getargspec"):
+    inspect.getargspec = lambda func: inspect.getfullargspec(func)[:4]
 
 
 class PluginProxy(object):

--- a/nose/util.py
+++ b/nose/util.py
@@ -16,6 +16,8 @@ class_types = (ClassType, TypeType)
 skip_pattern = (
     r"(?:\.svn)|(?:[^.]+\.py[co])|(?:.*~)|(?:.*\$py\.class)|(?:__pycache__)"
 )
+if not hasattr(inspect, "getargspec"):
+    inspect.getargspec = lambda func: inspect.getfullargspec(func)[:4]
 try:
     set()
 except NameError:
@@ -422,8 +424,9 @@ def try_run(obj, names):
                     ):
                         func = func.__call__
                     try:
-                        args, varargs, varkw, defaults = \
+                        args, varargs, varkw, defaults = (
                             inspect.getargspec(func)
+                        )
                         args.pop(0)  # pop the self off
                     except TypeError:
                         raise TypeError("Attribute %s of %r is not a python "


### PR DESCRIPTION
## Fix issue with "inspect" on Python 3.11
* Fix issue with ``inspect`` on Python 3.11
--> https://github.com/mdmintz/pynose/commit/0775045116a9b82c926e1654d249325f63bbed80
--> Fixes ``AttributeError: module 'inspect' has no attribute 'getargspec'.``
--> This resolves https://github.com/mdmintz/pynose/issues/4