### PR TITLE
README.md: Remove distracting syntax highlighting colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ https://nose.readthedocs.io/en/latest/
 
 --------
 
-```bash
+```
 
 Basic usage
 ***********


### PR DESCRIPTION
These misplaced color changes distract the reader.
```bash
If you do not want the test script to exit with 0 on success and 1 on
failure (like unittest.main), use nose.run() instead:
```
-->
```
If you do not want the test script to exit with 0 on success and 1 on
failure (like unittest.main), use nose.run() instead:
```