### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ removed:
    verbosity=3
    with-doctest=1
 
-There is also possiblity to disable configuration files loading (might
-be useful when runnig i.e. tox and you do not want your global nose
+There is also possibility to disable configuration files loading (might
+be useful when running i.e. tox and you do not want your global nose
 config file to be used by tox). In order to ignore those configuration
 files simply set an environment variable "NOSE_IGNORE_CONFIG_FILES".
 

--- a/nose/plugins/doctests.py
+++ b/nose/plugins/doctests.py
@@ -92,7 +92,7 @@ class Doctest(Plugin):
     suiteClass = DoctestSuite
 
     def options(self, parser, env):
-        """Register commmandline options."""
+        """Register commandline options."""
         Plugin.options(self, parser, env)
         parser.add_option(
             '--doctest-tests', action='store_true', dest='doctest_tests',
@@ -329,7 +329,7 @@ class DocTestCase(doctest.DocTestCase):
 
     # doctests loaded via find(obj) omit the module name
     # so we need to override id, __repr__ and shortDescription
-    # bonus: this will squash a 2.3 vs 2.4 incompatiblity
+    # bonus: this will squash a 2.3 vs 2.4 incompatibility
     def id(self):
         name = self._dt_test.name
         filename = self._dt_test.filename

--- a/nose/plugins/failuredetail.py
+++ b/nose/plugins/failuredetail.py
@@ -11,7 +11,7 @@ class FailureDetail(Plugin):
     score = 1600  # before capture
 
     def options(self, parser, env):
-        """Register commmandline options."""
+        """Register commandline options."""
         parser.add_option(
             "-d", "--detailed-errors", "--failure-detail", action="store_true",
             default=env.get('NOSE_DETAILED_ERRORS'), dest="detailedErrors",

--- a/nose/twistedtools.py
+++ b/nose/twistedtools.py
@@ -84,7 +84,7 @@ def deferred(timeout=None):
     The optional timeout parameter specifies the maximum duration of the test.
     The difference with timed() is that timed() will still wait for the test
     to end, while deferred() will stop the test when its timeout has expired.
-    The latter is more desireable when dealing with network tests, because
+    The latter is more desirable when dealing with network tests, because
     the result may actually never arrive.
 
     If the callback is triggered, the test has passed.


### PR DESCRIPTION
% `codespell --ignore-words-list=ned --write-changes`
* https://pypi.org/project/codespell