### PR TITLE
Use comprehensions and other ruff simplifications

### DIFF
--- a/nose/case.py
+++ b/nose/case.py
@@ -153,7 +153,7 @@ class Test(unittest.TestCase):
             pass
         try:
             if desc == str(self.test):
-                return
+                return None
         except Exception:
             pass
         return desc
@@ -186,7 +186,7 @@ class FunctionTestCase(TestBase):
     __test__ = False  # do not collect
 
     def __init__(
-        self, test, setUp=None, tearDown=None, arg=tuple(), descriptor=None
+        self, test, setUp=None, tearDown=None, arg=(), descriptor=None
     ):
         """Initialize the MethodTestCase.
         Required argument:
@@ -267,7 +267,7 @@ class MethodTestCase(TestBase):
     create test cases for test methods."""
     __test__ = False  # do not collect
 
-    def __init__(self, method, test=None, arg=tuple(), descriptor=None):
+    def __init__(self, method, test=None, arg=(), descriptor=None):
         """Initialize the MethodTestCase.
         Required argument:
         * method -- the method to call, may be bound or unbound. In either

--- a/nose/plugins/allmodules.py
+++ b/nose/plugins/allmodules.py
@@ -21,6 +21,7 @@ class AllModules(Plugin):
         """Override to return True for all files ending with .py"""
         if file.endswith('.py'):
             return True
+        return None
 
     def wantModule(self, module):
         """Override return True for all modules"""

--- a/nose/plugins/allmodules.py
+++ b/nose/plugins/allmodules.py
@@ -19,7 +19,9 @@ class AllModules(Plugin):
 
     def wantFile(self, file):
         """Override to return True for all files ending with .py"""
-        return file.endswith('.py')
+        if file.endswith('.py'):
+            return True
+        return None
 
     def wantModule(self, module):
         """Override return True for all modules"""

--- a/nose/plugins/allmodules.py
+++ b/nose/plugins/allmodules.py
@@ -19,9 +19,7 @@ class AllModules(Plugin):
 
     def wantFile(self, file):
         """Override to return True for all files ending with .py"""
-        if file.endswith('.py'):
-            return True
-        return None
+        return file.endswith('.py')
 
     def wantModule(self, module):
         """Override return True for all modules"""

--- a/nose/plugins/attrib.py
+++ b/nose/plugins/attrib.py
@@ -208,13 +208,12 @@ class AttributeSelector(Plugin):
                                                   for x in attr]:
                         match = False
                         break
-                else:
-                    if (
-                        value != attr
-                        and str(value).lower() != str(attr).lower()
-                    ):
-                        match = False
-                        break
+                elif (
+                    value != attr
+                    and str(value).lower() != str(attr).lower()
+                ):
+                    match = False
+                    break
             any = any or match
         if any:
             return None

--- a/nose/plugins/capture.py
+++ b/nose/plugins/capture.py
@@ -49,11 +49,9 @@ class Capture(Plugin):
         """Configure plugin. Plugin is enabled by default."""
         self.conf = conf
         if (
-            "NOSE_CAPTURE" in os.environ.keys()
+            "NOSE_CAPTURE" in os.environ
             and os.environ["NOSE_CAPTURE"] == "1"
-        ):
-            self.enabled = True
-        elif options.capture_output:
+        ) or options.capture_output:
             self.enabled = True
         elif not options.capture:
             self.enabled = False
@@ -116,5 +114,6 @@ class Capture(Plugin):
     def _get_buffer(self):
         if self._buf is not None:
             return self._buf.getvalue()
+        return None
 
     buffer = property(_get_buffer, None, None, """Captured stdout output.""")

--- a/nose/plugins/collect.py
+++ b/nose/plugins/collect.py
@@ -37,7 +37,7 @@ class CollectOnly(Plugin):
         """Replace actual test with dummy that always passes."""
         log.debug("Preparing test case %s", test)
         if not isinstance(test, Test):
-            return
+            return None
 
         def run(result):
             self.conf.plugins.startTest(test)

--- a/nose/plugins/cover.py
+++ b/nose/plugins/cover.py
@@ -94,8 +94,8 @@ class Coverage(Plugin):
                 if not hasattr(coverage, 'coverage'):
                     raise ImportError("Unable to import coverage module")
             except ImportError:
-                log.exception("Coverage not available: "
-                              "unable to import coverage module")
+                log.error("Coverage not available: "
+                          "unable to import coverage module")
                 self.enabled = False
                 return
         self.conf = conf

--- a/nose/plugins/cover.py
+++ b/nose/plugins/cover.py
@@ -94,8 +94,8 @@ class Coverage(Plugin):
                 if not hasattr(coverage, 'coverage'):
                     raise ImportError("Unable to import coverage module")
             except ImportError:
-                log.error("Coverage not available: "
-                          "unable to import coverage module")
+                log.exception("Coverage not available: "
+                              "unable to import coverage module")
                 self.enabled = False
                 return
         self.conf = conf

--- a/nose/plugins/errorclass.py
+++ b/nose/plugins/errorclass.py
@@ -113,10 +113,11 @@ class ErrorClassPlugin(Plugin, metaclass=MetaErrorClass):
     def addError(self, test, err):
         err_cls, a, b = err
         if not isclass(err_cls):
-            return
+            return None
         classes = [e[0] for e in self.errorClasses]
         if [c for c in classes if issubclass(err_cls, c)]:
             return True
+        return None
 
     def prepareTestResult(self, result):
         if not hasattr(result, 'errorClasses'):

--- a/nose/plugins/isolate.py
+++ b/nose/plugins/isolate.py
@@ -67,7 +67,7 @@ class IsolationPlugin(Plugin):
         around each name. The side-effect of this is that full context
         fixtures will be set up and torn down around each test named."""
         if not names or len(names) == 1:
-            return
+            return None
         loader = self.loader
         plugins = self.conf.plugins
 

--- a/nose/plugins/logcapture.py
+++ b/nose/plugins/logcapture.py
@@ -81,6 +81,7 @@ class MyMemoryHandler(Handler):
     def filter(self, record):
         if self.filterset.allow(record.name):
             return Handler.filter(self, record)
+        return None
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/nose/plugins/manager.py
+++ b/nose/plugins/manager.py
@@ -121,8 +121,7 @@ class PluginProxy(object):
             try:
                 result = meth(*arg, **kw)
                 if result is not None:
-                    for r in result:
-                        yield r
+                    yield from result
             except (KeyboardInterrupt, SystemExit):
                 raise
             except Exception:
@@ -136,6 +135,7 @@ class PluginProxy(object):
             result = meth(*arg, **kw)
             if result is not None:
                 return result
+        return None
 
     def _loadTestsFromNames(self, names, module=None):
         """Chainable but not quite normal. Plugins return a tuple of
@@ -279,16 +279,16 @@ class ZeroNinePlugin:
 
     def addError(self, test, err):
         if not hasattr(self.plugin, 'addError'):
-            return
+            return None
         from nose.exc import SkipTest, DeprecatedTest
         ec, ev, tb = err
         if issubclass(ec, SkipTest):
             if not hasattr(self.plugin, 'addSkip'):
-                return
+                return None
             return self.plugin.addSkip(test.test)
         elif issubclass(ec, DeprecatedTest):
             if not hasattr(self.plugin, 'addDeprecated'):
-                return
+                return None
             return self.plugin.addDeprecated(test.test)
         capt = test.capturedOutput
         return self.plugin.addError(test.test, err, capt)
@@ -296,10 +296,11 @@ class ZeroNinePlugin:
     def loadTestsFromFile(self, filename):
         if hasattr(self.plugin, 'loadTestsFromPath'):
             return self.plugin.loadTestsFromPath(filename)
+        return None
 
     def addFailure(self, test, err):
         if not hasattr(self.plugin, 'addFailure'):
-            return
+            return None
         capt = test.capturedOutput
         tbinfo = test.tbinfo
         return self.plugin.addFailure(test.test, err, capt, tbinfo)
@@ -312,12 +313,12 @@ class ZeroNinePlugin:
 
     def startTest(self, test):
         if not hasattr(self.plugin, 'startTest'):
-            return
+            return None
         return self.plugin.startTest(test.test)
 
     def stopTest(self, test):
         if not hasattr(self.plugin, 'stopTest'):
-            return
+            return None
         return self.plugin.stopTest(test.test)
 
     def __getattr__(self, val):

--- a/nose/plugins/multiprocess.py
+++ b/nose/plugins/multiprocess.py
@@ -400,7 +400,7 @@ class MultiProcessTestRunner(TextTestRunner):
                                         > self.waitkilltime
                                     ):
                                         msg = "terminating worker %s"
-                                        log.exception(msg, iworker)
+                                        log.error(msg, iworker)
                                         w.terminate()
                                         workers[iworker] = w = (
                                             self.startProcess(

--- a/nose/plugins/multiprocess.py
+++ b/nose/plugins/multiprocess.py
@@ -331,7 +331,7 @@ class MultiProcessTestRunner(TextTestRunner):
                         try:
                             tasks.remove(addr)
                         except ValueError:
-                            log.warn(
+                            log.warning(
                                 'worker %s failed to remove from tasks: %s',
                                 iworker, addr,
                             )
@@ -400,7 +400,7 @@ class MultiProcessTestRunner(TextTestRunner):
                                         > self.waitkilltime
                                     ):
                                         msg = "terminating worker %s"
-                                        log.error(msg, iworker)
+                                        log.exception(msg, iworker)
                                         w.terminate()
                                         workers[iworker] = w = (
                                             self.startProcess(
@@ -531,8 +531,7 @@ class MultiProcessTestRunner(TextTestRunner):
             yield test
         else:
             for case in test:
-                for batch in self.nextBatch(case):
-                    yield batch
+                yield from self.nextBatch(case)
 
     def checkCanSplit(context, fixt):
         """Callback to check whether the fixtures found in a context or

--- a/nose/suite.py
+++ b/nose/suite.py
@@ -319,7 +319,7 @@ class ContextSuite(LazySuite):
 
     def _get_wrapped_tests(self):
         for test in self._get_tests():
-            if isinstance(test, Test) or isinstance(test, unittest.TestSuite):
+            if isinstance(test, (Test, unittest.TestSuite)):
                 yield test
             else:
                 yield Test(
@@ -373,9 +373,7 @@ class ContextSuiteFactory(object):
         log.debug("get ancestry %s", context)
         if context is None:
             return
-        if hasattr(context, 'im_class'):
-            context = context.__self__.__class__
-        elif hasattr(context, '__self__'):
+        if hasattr(context, 'im_class') or hasattr(context, '__self__'):
             context = context.__self__.__class__
         if hasattr(context, '__module__'):
             ancestors = context.__module__.split('.')
@@ -390,8 +388,7 @@ class ContextSuiteFactory(object):
 
     def findContext(self, tests):
         if (
-            isinstance(tests, collections.abc.Callable)
-            or isinstance(tests, unittest.TestSuite)
+            isinstance(tests, (collections.abc.Callable, unittest.TestSuite))
         ):
             return None
         context = None
@@ -432,7 +429,7 @@ class ContextSuiteFactory(object):
         tail = tests[:]
         context = getattr(head, 'context', None)
         if context is not None:
-            ancestors = [context] + [a for a in self.ancestry(context)]
+            ancestors = [context] + list(self.ancestry(context))
             for ancestor in ancestors:
                 common = [suite]
                 remain = []
@@ -460,15 +457,14 @@ class ContextSuiteFactory(object):
     def wrapTests(self, tests):
         log.debug("wrap %s", tests)
         if (
-            isinstance(tests, collections.abc.Callable)
-            or isinstance(tests, unittest.TestSuite)
+            isinstance(tests, (collections.abc.Callable, unittest.TestSuite))
         ):
             log.debug("I won't wrap")
             return tests
         wrapped = []
         for test in tests:
             log.debug("wrapping %s", test)
-            if isinstance(test, Test) or isinstance(test, unittest.TestSuite):
+            if isinstance(test, (Test, unittest.TestSuite)):
                 wrapped.append(test)
             elif isinstance(test, ContextList):
                 wrapped.append(self.makeSuite(test, context=test.context))

--- a/nose/util.py
+++ b/nose/util.py
@@ -88,7 +88,7 @@ def absfile(path, where=None):
     orig = path
     if where is None:
         where = os.getcwd()
-    if isinstance(where, list) or isinstance(where, tuple):
+    if isinstance(where, (list, tuple)):
         for maybe_path in where:
             maybe_abs = absfile(path, maybe_path)
             if maybe_abs is not None:
@@ -113,10 +113,7 @@ def absfile(path, where=None):
 
 
 def anyp(predicate, iterable):
-    for item in iterable:
-        if predicate(item):
-            return True
-    return False
+    return any(predicate(item) for item in iterable)
 
 
 def file_like(name):
@@ -412,7 +409,7 @@ def try_run(obj, names):
                 else:
                     # Not a function. If it's callable, call it anyway.
                     if (
-                        hasattr(func, '__call__')
+                        callable(func)
                         and not inspect.ismethod(func)
                     ):
                         func = func.__call__
@@ -431,6 +428,7 @@ def try_run(obj, names):
                     return func(obj)
             log.debug("call fixture %s.%s", obj, name)
             return func()
+    return None
 
 
 def src(filename):
@@ -562,8 +560,7 @@ def transplant_func(func, module):
 
     if isgenerator(func):
         def newfunc(*arg, **kw):
-            for v in func(*arg, **kw):
-                yield v
+            yield from func(*arg, **kw)
     else:
         def newfunc(*arg, **kw):
             return func(*arg, **kw)

--- a/setup.py
+++ b/setup.py
@@ -71,15 +71,15 @@ if sys.argv[-1] == "publish":
         print("\n>>> The Release was NOT PUBLISHED to PyPI! <<<\n")
     sys.exit()
 
-addl_args = dict(
-    packages=["nose", "nose.plugins", "nose.sphinx", "nose.tools"],
-    entry_points={
+addl_args = {
+    "packages": ["nose", "nose.plugins", "nose.sphinx", "nose.tools"],
+    "entry_points": {
         "console_scripts": [
             "nosetests = nose.core:run_exit",
             "pynose = nose.core:run_exit",
         ]
     },
-)
+}
 
 setup(
     name="pynose",


### PR DESCRIPTION
% `ruff --select=B004,G010,PLR1701,PLR5501,RET502,SIM114 --fix`
```
Found 23 errors (23 fixed, 0 remaining).
```
% `ruff --select=C4,RET503,SIM110,SIM118,TRY400,UP028 --fix --unsafe-fixes`
```
Found 23 errors (23 fixed, 0 remaining).
```
% `ruff rule B004`
# unreliable-callable-check (B004)

Derived from the **flake8-bugbear** linter.

Fix is sometimes available.

## What it does
Checks for uses of `hasattr` to test if an object is callable (e.g.,
`hasattr(obj, "__call__")`).

## Why is this bad?
Using `hasattr` is an unreliable mechanism for testing if an object is
callable. If `obj` implements a custom `__getattr__`, or if its `__call__`
is itself not callable, you may get misleading results.

Instead, use `callable(obj)` to test if `obj` is callable.

## Example
```python
hasattr(obj, "__call__")
```

Use instead:
```python
callable(obj)
```

## References
- [Python documentation: `callable`](https://docs.python.org/3/library/functions.html#callable)
- [Python documentation: `hasattr`](https://docs.python.org/3/library/functions.html#hasattr)
- [Python documentation: `__getattr__`](https://docs.python.org/3/reference/datamodel.html#object.__getattr__)
- [Python documentation: `__call__`](https://docs.python.org/3/reference/datamodel.html#object.__call__)
