### PR TITLE
Add an option to show skipped test cases by attrs

### DIFF
--- a/nose/config.py
+++ b/nose/config.py
@@ -175,6 +175,8 @@ class Config(object):
         self.configSection = 'nosetests'
         self.debug = env.get('NOSE_DEBUG')
         self.debugLog = env.get('NOSE_DEBUG_LOG')
+        self.logPropagate = bool(env.get('NOSE_LOG_PROPAGATE', False))
+        self.logNoLogHandlers = bool(env.get('NOSE_NO_LOG_HANDLERS', False))
         self.exclude = None
         self.getTestCaseNamesCompat = False
         self.includeExe = env.get(
@@ -333,7 +335,7 @@ class Config(object):
             handler = logging.StreamHandler(self.logStream)
         handler.setFormatter(format)
         logger = logging.getLogger('nose')
-        logger.propagate = 0
+        logger.propagate = self.logPropagate
         found = False
         if self.debugLog:
             debugLogAbsPath = os.path.abspath(self.debugLog)
@@ -352,6 +354,10 @@ class Config(object):
                     found = True
         if not found:
             logger.addHandler(handler)
+
+        if self.logNoLogHandlers:
+            logger.handlers = []
+
         lvl = logging.WARNING
         if self.verbosity >= 5:
             lvl = 0


### PR DESCRIPTION
Hi, thank you for the update nose to support py3.10 to py3.13. It helps a lot to our team. In our team, we also [add some functions](https://github.com/bmwcarit/nose3) to show skip tests and control the logger in a more sophisticated way. Can you help to review and merge the PR? Thank you.
  
1. Add `--verbose-skipped-attr` option to show skipped test cases by attrs
2. Add `NOSE_LOG_PROPAGATE` env to determine to pass the log config to child loggers or not.
3. Add `NOSE_NO_LOG_HANDLERS` env to bypass all log handlers. It's useful when the logger is set before call the nose program (i.e. the nose is used as a library.)