### PR TITLE
Tee should have a public encoding attr

### DIFF
--- a/nose/plugins/xunit.py
+++ b/nose/plugins/xunit.py
@@ -105,11 +105,11 @@ def exc_message(exc_info):
 
 class Tee(object):
     def __init__(self, encoding, *args):
-        self._encoding = encoding
+        self.encoding = encoding
         self._streams = args
 
     def write(self, data):
-        data = force_unicode(data, self._encoding)
+        data = force_unicode(data, self.encoding)
         for s in self._streams:
             s.write(data)
 


### PR DESCRIPTION
As also in the original nose library, the Tee object should have a public `encoding` attribute instead of it being hidden. See https://github.com/nose-devs/nose/blob/7c26ad1e6b7d308cafa328ad34736d34028c122a/nose/plugins/xunit.py#L129

As we use nose in combination with doctests, we get an attribute error when doctest tries to get the encoding of what doctest thinks is just a stdout, but because we use nose, it is a Tee object. Which would be fine, if it had the same attributes.
See https://github.com/python/cpython/blob/v3.8.20/Lib/doctest.py#L1452